### PR TITLE
Fixed warnings from GCC

### DIFF
--- a/src/elfc/MakeElfC
+++ b/src/elfc/MakeElfC
@@ -1,6 +1,6 @@
 # Define macros for common values
 CC = cl
-CFLAGS = /W3 /Zi /D_CRT_SECURE_NO_WARNINGS /nologo
+CFLAGS = /W3 /Zi /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS /nologo
 LFLAGS = /nologo
 
 # Define the target executable

--- a/src/elfc/decl.c
+++ b/src/elfc/decl.c
@@ -568,11 +568,11 @@ static int localdecls(void) {
 				  error (invalid, "const");
 				Token = scan();
         if (VOLATILE == Token || (IDENT == Token && (utype = usertype(Text)) != 0)) {
-					if (VOLATILE == Token)
+          if (VOLATILE == Token) {
 					  if (vltl)
 						  error(invalid, "volatile");
 						else vltl = 1;
-
+          }
 					Token = scan();
 				}
 			} else if (VOLATILE == Token) {

--- a/src/elfc/sym.c
+++ b/src/elfc/sym.c
@@ -479,10 +479,8 @@ int findLocalLabel(int scope, char *text) {
 	return llid;
 }
 
-//grw - for compilers after C99
-#ifndef __SUBC__
-#define strdup _strdup
-#endif
+//grw - moved warning suppression to NMake file
+
 //grw - added support for local labels and goto
 int addLocalLabel(int fn, char *text, int defined) {
 	int llid = 0;


### PR DESCRIPTION
Updated the MakeFile and the source code to eliminate warnings when building with GCC in Linux