### PR TITLE
Add support for linker update of version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.lst
 *.prg
 *.build
+*.lkb
 *.elfos
 src/clib/ctype/*.asm
 src/clib/stdio/*.asm

--- a/src/clib/crt0/Makefile
+++ b/src/clib/crt0/Makefile
@@ -10,5 +10,5 @@ $(TARGET): $(SRCS)
 	$(ASM) $(ASMFLAGS) $^ && mv $(TARGET) ../lib
 
 clean:
-	rm -f *.lst *.build
+	rm -f *.lst *.build $(TARGET)
 

--- a/src/clib/crt0/crt0.asm
+++ b/src/clib/crt0/crt0.asm
@@ -96,9 +96,10 @@
 
 ElfCpgm:  br     Elfstart
           ever
-  					db 'ElfC',0
-Elfstart: push   r6            ; save original return address on stack
-          load   rf, ostack    ; save original SP
+.link     .ever               ; tell linker to update header
+          db 'ElfC',0
+Elfstart: push   r6           ; save original return address on stack
+          load   rf, ostack   ; save original SP
           ghi    r2
           str    rf
           inc    rf
@@ -137,7 +138,7 @@ Elfexit:  load   rf, ostack   ; get original SP
           plo    r2
           sex    2            ; make sure X = SP for return
           pop    r6           ; restore original return
-          glo    ra						; get byte value for return
+          glo    ra           ; get byte value for return
           rtn                 ; return to Elf/OS
 
 ;----- error handling for when expression stack exhausted
@@ -275,7 +276,7 @@ cstk:   ds 127
 cstack: db 0          	; progam stack
 ;----------------------- Expression Stack ---------------------------
 estk:   ds 32           ; minimum stack for arithmetic operations
-es_min: ds 223					; auto variables and arithmetic operations
+es_min: ds 223          ; auto variables and arithmetic operations
 estack: db 0            ; Top of expression stack
 ;----------------------- Arguments for Main ---------------------------
 m_argc:   db   0        ; arguement count

--- a/src/clib/lib/crt0.prg
+++ b/src/clib/lib/crt0.prg
@@ -3,26 +3,28 @@
 =auto_err 2066
 =stk_err 209c
 =Elfexit 2054
-:2000 30 0d 81 0a 07 ea 01 50 45 6c 66 43 00 96 73 86
-:2010 73 f8 e1 af f8 21 bf 92 5f 1f 82 5f f8 62 a2 f8
-:2020 22 b2 f8 62 a7 f8 23 b7 87 ab 97 bb f8 01 a9 f8
+:2000 30 0d 81 0c 07 ea 00 01
+.ever               ; tell linker to update header
+:2008 45 6c 66 43 00 96 73 86 73 f8 e1 af f8 21 bf 92
+:2018 5f 1f 82 5f f8 62 a2 f8 22 b2 f8 62 a7 f8 23 b7
 /C_init 2033 00
 \C_init 2034
-:2030 21 b9 d4 00 00 d4 20 be f8 63 ad f8 23 bd f8 64
-:2040 af f8 23 bf e7 9f 73 8f 73 f8 00 73 0d 73 e2 d4
+:2028 87 ab 97 bb f8 01 a9 f8 21 b9 d4 00 00 d4 20 be
+:2038 f8 63 ad f8 23 bd f8 64 af f8 23 bf e7 9f 73 8f
 /Cmain 2050 00
 \Cmain 2051
-:2050 00 00 fc 00 f8 e1 af f8 21 bf 4f b2 0f a2 e2 60
-:2060 72 a6 f0 b6 8a d5 d4 03 4b 4f 75 74 20 6f 66 20
-:2070 53 74 61 63 6b 20 53 70 61 63 65 20 66 6f 72 20
-:2080 41 75 74 6f 20 56 61 72 69 61 62 6c 65 73 0a 0d
-:2090 00 f8 ff aa f8 ff ba ff 00 c0 20 54 d4 03 4b 53
-:20a0 74 61 63 6b 20 43 72 65 65 70 20 45 72 72 6f 72
-:20b0 0a 0d 00 f8 ff aa f8 ff ba ff 00 c0 20 54 f8 63
-:20c0 ad f8 23 bd f8 64 af f8 23 bf f8 00 ac f8 00 bc
-:20d0 f8 80 a8 f8 00 b8 48 c2 20 fb ff 20 c2 20 d6 28
-:20e0 88 5f 1f 98 5f 1f 1c 48 c2 20 fb ff 20 ca 20 e7
-:20f0 28 f8 00 58 18 8c ff 08 ca 20 d6 8c 5d d5
+:2048 73 f8 00 73 0d 73 e2 d4 00 00 fc 00 f8 e1 af f8
+:2058 21 bf 4f b2 0f a2 e2 60 72 a6 f0 b6 8a d5 d4 03
+:2068 4b 4f 75 74 20 6f 66 20 53 74 61 63 6b 20 53 70
+:2078 61 63 65 20 66 6f 72 20 41 75 74 6f 20 56 61 72
+:2088 69 61 62 6c 65 73 0a 0d 00 f8 ff aa f8 ff ba ff
+:2098 00 c0 20 54 d4 03 4b 53 74 61 63 6b 20 43 72 65
+:20a8 65 70 20 45 72 72 6f 72 0a 0d 00 f8 ff aa f8 ff
+:20b8 ba ff 00 c0 20 54 f8 63 ad f8 23 bd f8 64 af f8
+:20c8 23 bf f8 00 ac f8 00 bc f8 80 a8 f8 00 b8 48 c2
+:20d8 20 fb ff 20 c2 20 d6 28 88 5f 1f 98 5f 1f 1c 48
+:20e8 c2 20 fb ff 20 ca 20 e7 28 f8 00 58 18 8c ff 08
+:20f8 ca 20 d6 8c 5d d5
 ?esmove 2104
 ?stkchk 2107
 ?dpop16 210a

--- a/src/clib/time/Makefile
+++ b/src/clib/time/Makefile
@@ -1,7 +1,7 @@
 CC = elfc
 CFLAGS = -L
 
-SRCS = _dow.c _doy.c systime.c asctime.c cstime.c timezone.c utctime.c strftime.c
+SRCS = _dow.c _doy.c asctime.c cstime.c strftime.c systime.c timezone.c utctime.c
 OBJS = $(SRCS:.c=.prg)
 TARGET = time.lib
 

--- a/src/examples/Makefile
+++ b/src/examples/Makefile
@@ -9,4 +9,4 @@ all:
 
 # A clean target to remove generated files
 clean:
-	rm -f *.prg *.asm *.lst *.build *.sym *.elfos
+	rm -f *.prg *.asm *.lst *.build *.lkb *.sym *.elfos

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -9,4 +9,4 @@ all:
 
 # A clean target to remove generated files
 clean:
-	rm -f *.prg *.asm *.lst *.build *.sym *.elfos
+	rm -f *.prg *.asm *.lst *.build *.lkb *.sym *.elfos


### PR DESCRIPTION
I added the .link ever directive in crt0.asm and I handled the .lkb files in my makefiles. You would need to get the latest Asm/02 (v1.13) and Link/02 (v1.6) for these changes to work correctly.