### PR TITLE
Moved dependencies on math32 library down to individual modules

### DIFF
--- a/src/clib/include/stdio.h
+++ b/src/clib/include/stdio.h
@@ -6,11 +6,6 @@
 #include <stdlib.h>
 #endif
 
-/* math32 functions used by fseek32 and fsetpos */
-#ifndef _ELFCLIB_
-#pragma .link .library math32.lib
-#endif
-
 /* Maximum size of string in Elf/OS is 255 bytes */
 #ifndef _BUFLEN
 #define _BUFLEN 256

--- a/src/clib/lib/stdio.lib
+++ b/src/clib/lib/stdio.lib
@@ -1825,6 +1825,7 @@ v02cf
 }
 .big
 {Cfseek32
+.library math32.lib
 ?auto_err 000e
 :0000 e2 9b 73 8b 73 87 ab 97 bb d9 03 ff fe c3 00 00
 ?auto_err 0015
@@ -1906,6 +1907,7 @@ v02cf
 }
 .big
 {Cfsetpos
+.library math32.lib
 ?auto_err 000e
 :0000 e2 9b 73 8b 73 87 ab 97 bb d9 03 ff fe c3 00 00
 ?auto_err 0015

--- a/src/clib/lib/stdlib.lib
+++ b/src/clib/lib/stdlib.lib
@@ -541,6 +541,7 @@ v0037
 }
 .big
 {Clseek32
+.library math32.lib
 ?auto_err 000e
 :0000 e2 9b 73 8b 73 87 ab 97 bb d9 03 ff fe c3 00 00
 ?auto_err 0015

--- a/src/clib/stdio/fseek32.c
+++ b/src/clib/stdio/fseek32.c
@@ -12,6 +12,7 @@
 #pragma             extrn Clseek32
 #pragma             extrn Cto_int32
 #pragma             extrn Ccmp32
+#pragma .link .library math32.lib
 
 int fseek32(FILE *f, off_t *offset, int whence) {
   int hi;

--- a/src/clib/stdio/fsetpos.c
+++ b/src/clib/stdio/fsetpos.c
@@ -8,6 +8,7 @@
 #pragma             extrn Clseek32
 #pragma             extrn Cto_int32
 #pragma             extrn Ccmp32
+#pragma .link .library math32.lib
 
 int fsetpos(FILE *f, pos_t *pos) {
     off_t new_pos;

--- a/src/clib/stdlib/lseek32.c
+++ b/src/clib/stdlib/lseek32.c
@@ -1,33 +1,35 @@
 #define _ELFCLIB_
 #include <stdlib.h>
 #include <errno.h>
+#include <math32.h>
 
 #pragma             extrn Cerrno
 #pragma             extrn C_fildes
 #pragma             extrn Cto_int32
 #pragma             extrn Ccmp32
+#pragma .link .library math32.lib
 
 off_t lseek32(int fd, off_t *offset, int how) {
   int fildes;
   off_t result;
   off_t eof;
-  
+
   eof = to_int32(EOF);
-  
+
   /* get system file descriptor */
   fildes = _fildes(fd);
-  
+
   /* don't seek invalid fd */
   if(fildes == EOF) {
     errno = EBADF;
     return eof;
   }
-  
+
   asm("         gosub s_lget16  ; get the fildes variable ");
-  asm("           dw -2         ; from local variable stack");           
+  asm("           dw -2         ; from local variable stack");
   asm("         copy ra, rd     ; copy fd to fildes register");
   asm("         gosub s_lget16  ; get the how to seek argument ");
-  asm("           dw 4          ; from argument stack");           
+  asm("           dw 4          ; from argument stack");
   asm("         copy ra, rc     ; copy how to seek value to register");
   asm("         gosub s_lget16  ; get the pointer to the offset");
   asm("           dw 2          ; from argument stack");
@@ -61,6 +63,6 @@ off_t lseek32(int fd, off_t *offset, int how) {
   if (cmp32(&result, &eof) == 0) {
     errno = EIO;
   }
-  
+
   return result;
 }


### PR DESCRIPTION
Small update to move the linker statement out of the header file and down into the individual source files themselves.