### PR TITLE
Pi fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 src/clib/ctype/*.asm
 src/clib/elfio/*.asm
 src/clib/elfstd/*.asm
-src/clib/math32/*.asm
+src/clib/mathi32/*.asm
 src/clib/stdio/*.asm
 src/clib/stdlib/*.asm
 src/clib/string/*.asm

--- a/src/elfc/sym.c
+++ b/src/elfc/sym.c
@@ -418,7 +418,7 @@ int objsize(int prim, int type, int size) {
 static char *typename(int p) {
   //grw - added support for multiple pointer indirection
   static char tname[14];
-  static char overflow[6];
+  static char overflow[15];
   int lvl;
   int btype;
 


### PR DESCRIPTION
Fixed a compiler warning on the Pi and updated .gitignore for 32-bit math library name change.