### PR TITLE
Fix for error in de-referencing an array pointer returned by a function

### DIFF
--- a/src/elfc/gen.c
+++ b/src/elfc/gen.c
@@ -1052,6 +1052,8 @@ void genrval(int *lv) {
   if (NULL == lv) return;
 
   y = lv[LVSYM];
+  //grw - added a commit to fix issue with array pointer returned from function
+  commit();
 
   if (!y) {
     genind(lv[LVPRIM]);


### PR DESCRIPTION
Quick fix for error in de-referencing a pointer to an array returned by a function with an array index.